### PR TITLE
EVA-1027 - Compare sample names in EVA VCF against Submission Metadata sheet 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+/.project

--- a/samples_checker/.pylintrc
+++ b/samples_checker/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook='import sys; sys.path.append("../xls2xml")'
+#init-hook=
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/samples_checker/.pylintrc
+++ b/samples_checker/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys; sys.path.append("../xls2xml")'
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/samples_checker/samples_checker/check_samples.py
+++ b/samples_checker/samples_checker/check_samples.py
@@ -30,11 +30,11 @@ def get_sample_diff(file_path, file_xml, sample_xml):
             print('Samples that appear in the Metadata sheet but not in the VCF: ' + file_name,
                   file=sys.stderr)
             print(difference_submission_xls_submitted_file, file=sys.stderr)
+    if not has_difference:
+        print('No differences found between the samples in the Metadata sheet and the VCF(s)!', file=sys.stdout)
     print('Samples checking completed!', file=sys.stdout)
     if has_difference:
         quit(1)
-    else:
-        print('No differences found between the samples in the Metadata sheet and the VCF(s)!', file=sys.stdout)
 
 
 def main():

--- a/samples_checker/samples_checker/check_samples.py
+++ b/samples_checker/samples_checker/check_samples.py
@@ -8,7 +8,7 @@ import argparse
 import utils
 
 
-def get_sample_diff(file_path, file_xml, sample_xml, submission_type="t2d"):
+def get_sample_diff(file_path, file_xml, sample_xml):
     submission_samples = utils.get_samples_from_xml(sample_xml)
     submitted_files = utils.get_files_from_xml(file_xml)
     has_difference = False
@@ -20,25 +20,21 @@ def get_sample_diff(file_path, file_xml, sample_xml, submission_type="t2d"):
         if difference_submitted_file_submission_xls:
             has_difference = True
             if file_type == 'vcf':
-                if submission_type == "t2d":
-                    print('The submission does not contain the following genotype ids:', file=sys.stderr)
-                if submission_type == "eva":
-                    print('Samples that appear in the VCF but not in the Metadata sheet:', file=sys.stderr)
+                print('Samples that appear in the VCF but not in the Metadata sheet:', file=sys.stderr)
             else:
                 print('The submission does not contain the following samples:', file=sys.stderr)
             print(difference_submitted_file_submission_xls, file=sys.stderr)
 
         if difference_submission_xls_submitted_file:
             has_difference = True
-            if submission_type == "t2d":
-                print('The following samples are not found in file ' + file_name, file=sys.stderr)
-            if submission_type == "eva":
-                print('Samples that appear in the Metadata sheet but not in the VCF: ' + file_name,
-                      file=sys.stderr)
+            print('Samples that appear in the Metadata sheet but not in the VCF: ' + file_name,
+                  file=sys.stderr)
             print(difference_submission_xls_submitted_file, file=sys.stderr)
+    print('Samples checking completed!', file=sys.stdout)
     if has_difference:
         quit(1)
-    print('Samples checking completed!', file=sys.stdout)
+    else:
+        print('No differences found between the samples in the Metadata sheet and the VCF(s)!', file=sys.stdout)
 
 
 def main():

--- a/samples_checker/samples_checker/check_samples.py
+++ b/samples_checker/samples_checker/check_samples.py
@@ -7,43 +7,57 @@ import sys
 import argparse
 import utils
 
-arg_parser = argparse.ArgumentParser(description='Check submission xls contains all samples that'
-                                                 'exist in the submitted files')
-arg_parser.add_argument('--sample-xml', required=True, dest='samplexml',
-                        help='XML file containing submission samples')
-arg_parser.add_argument('--file-xml', required=True, dest='filexml',
-                        help='XML file containing submitted files')
-arg_parser.add_argument('--file-path', required=True, dest='filepath',
-                        help='Path to the directory in which submitted files can be found')
 
-args = arg_parser.parse_args()
-sample_xml = args.samplexml
-file_xml = args.filexml
-file_path = args.filepath
+def get_sample_diff(file_path, file_xml, sample_xml, submission_type="t2d"):
+    submission_samples = utils.get_samples_from_xml(sample_xml)
+    submitted_files = utils.get_files_from_xml(file_xml)
+    has_difference = False
+    for file_name in submitted_files:
+        file_type = submitted_files.get(file_name, '')
+        difference_submission_xls_submitted_file, difference_submitted_file_submission_xls = \
+            utils.get_sample_difference(submission_samples, file_path + '/' + file_name, file_type)
 
-submission_samples = utils.get_samples_from_xml(sample_xml)
-submitted_files = utils.get_files_from_xml(file_xml)
+        if difference_submitted_file_submission_xls:
+            has_difference = True
+            if file_type == 'vcf':
+                if submission_type == "t2d":
+                    print('The submission does not contain the following genotype ids:', file=sys.stderr)
+                if submission_type == "eva":
+                    print('Samples that appear in the VCF but not in the Metadata sheet:', file=sys.stderr)
+            else:
+                print('The submission does not contain the following samples:', file=sys.stderr)
+            print(difference_submitted_file_submission_xls, file=sys.stderr)
 
-has_difference = False
-for file_name in submitted_files:
-    file_type = submitted_files.get(file_name, '')
-    difference_submission_xls_submitted_file, difference_submitted_file_submission_xls =\
-        utils.get_sample_difference(submission_samples, file_path + '/' + file_name, file_type)
+        if difference_submission_xls_submitted_file:
+            has_difference = True
+            if submission_type == "t2d":
+                print('The following samples are not found in file ' + file_name, file=sys.stderr)
+            if submission_type == "eva":
+                print('Samples that appear in the Metadata sheet but not in the VCF: ' + file_name,
+                      file=sys.stderr)
+            print(difference_submission_xls_submitted_file, file=sys.stderr)
+    if has_difference:
+        quit(1)
+    print('Samples checking completed!', file=sys.stdout)
 
-    if difference_submitted_file_submission_xls:
-        has_difference = True
-        if file_type == 'vcf':
-            print('The submission does not contain the following genotype ids:', file=sys.stderr)
-        else:
-            print('The submission does not contain the following samples:', file=sys.stderr)
-        print(difference_submitted_file_submission_xls, file=sys.stderr)
 
-    if difference_submission_xls_submitted_file:
-        has_difference = True
-        print('The following samples are not found in file '+file_name, file=sys.stderr)
-        print(difference_submission_xls_submitted_file, file=sys.stderr)
+def main():
+    arg_parser = argparse.ArgumentParser(description='Check submission xls contains all samples that'
+                                                     'exist in the submitted files')
+    arg_parser.add_argument('--sample-xml', required=True, dest='samplexml',
+                            help='XML file containing submission samples')
+    arg_parser.add_argument('--file-xml', required=True, dest='filexml',
+                            help='XML file containing submitted files')
+    arg_parser.add_argument('--file-path', required=True, dest='filepath',
+                            help='Path to the directory in which submitted files can be found')
 
-if has_difference:
-    quit(1)
+    args = arg_parser.parse_args()
+    sample_xml = args.samplexml
+    file_xml = args.filexml
+    file_path = args.filepath
 
-print('Samples checking completed!', file=sys.stdout)
+    get_sample_diff(file_path, file_xml, sample_xml)
+
+
+if __name__ == "__main__":
+    main()

--- a/xls2xml/xls2xml/xls2xml.py
+++ b/xls2xml/xls2xml/xls2xml.py
@@ -9,37 +9,44 @@ import argparse
 from XLSReader import XLSReader
 import utils
 
-arg_parser = argparse.ArgumentParser(
-    description='Transform and output validated data from an excel file to a XML file')
-arg_parser.add_argument('xls', help='Excel file to be validated and transformed')
-arg_parser.add_argument('xml', help='XML file to be written to')
-arg_parser.add_argument('--conf', required=True, dest='conf',
-                        help='Configuration file contains list of worksheets and fields')
-arg_parser.add_argument('--conf-key', required=True, dest='confKey',
-                        help='Keys/tabs (comma delimited) to retrieve the list of field')
-arg_parser.add_argument('--schema', required=True, dest='schema',
-                        help='Schema definition for data field')
-arg_parser.add_argument('--xslt', required=True, dest='xslt',
-                        help='Definition for transformation from xls to xml document')
 
-args = arg_parser.parse_args()
-xls_filename = args.xls
-xml_filename = args.xml
-xls_conf = args.conf
-xls_conf_keys = args.confKey.split(',')
-xls_schema = args.schema
-xslt_filename = args.xslt
+def convert_xls_to_xml(xls_conf, xls_conf_keys, xls_schema, xslt_filename, xls_filename, xml_filename):
+    xls_reader = XLSReader(xls_filename, xls_conf)
+    xls_readers = [(key, xls_reader) for key in xls_conf_keys]
+    try:
+        output_xml = utils.multiple_objects_to_xml(xls_readers, xls_schema, xslt_filename)
+    except Exception as e:
+        print(e.message, file=sys.stderr)
+        quit(1)
+    with open(xml_filename, 'w') as xml_file:
+        utils.save_xml(output_xml, xml_file)
+    print('Conversion complete!', file=sys.stdout)
 
-xls_reader = XLSReader(xls_filename, xls_conf)
-xls_readers = [ (key, xls_reader) for key in xls_conf_keys ]
 
-try:
-    output_xml = utils.multiple_objects_to_xml(xls_readers, xls_schema, xslt_filename)
-except Exception as e:
-    print(e.message, file=sys.stderr)
-    quit(1)
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description='Transform and output validated data from an excel file to a XML file')
+    arg_parser.add_argument('xls', help='Excel file to be validated and transformed')
+    arg_parser.add_argument('xml', help='XML file to be written to')
+    arg_parser.add_argument('--conf', required=True, dest='conf',
+                            help='Configuration file contains list of worksheets and fields')
+    arg_parser.add_argument('--conf-key', required=True, dest='confKey',
+                            help='Keys/tabs (comma delimited) to retrieve the list of field')
+    arg_parser.add_argument('--schema', required=True, dest='schema',
+                            help='Schema definition for data field')
+    arg_parser.add_argument('--xslt', required=True, dest='xslt',
+                            help='Definition for transformation from xls to xml document')
 
-with open(xml_filename, 'w') as xml_file:
-    utils.save_xml(output_xml, xml_file)
+    args = arg_parser.parse_args()
+    xls_filename = args.xls
+    xml_filename = args.xml
+    xls_conf = args.conf
+    xls_conf_keys = args.confKey.split(',')
+    xls_schema = args.schema
+    xslt_filename = args.xslt
 
-print('Conversion complete!', file=sys.stdout)
+    convert_xls_to_xml(xls_conf, xls_conf_keys, xls_schema, xslt_filename, xls_filename, xml_filename)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
.gitignore - Updated to exclude property files for GitEye

check_samples.py, xls2xml.py - Enclosed core logic inside a function so that it can be reused from other modules. Defined separate main to enable this module to be imported from other modules.

The updates above are only for this repository. The core functionality for EVA sample checker is in another repository: https://github.com/EBIvariation/eva-submission